### PR TITLE
fix(xsfetch): make `retry` work, remove the exposure of `retryCount`

### DIFF
--- a/packages/xsfetch/src/index.ts
+++ b/packages/xsfetch/src/index.ts
@@ -1,18 +1,18 @@
 import { sleep } from '../../utils-stream/src/_sleep'
 
 export interface CreateFetchOptions {
+  debug: boolean
   retry: number
   retryDelay: number
   retryStatusCodes: number[]
-  debug: boolean
 }
 
 export const defaultCreateFetchOptions: CreateFetchOptions = {
+  debug: false,
   retry: 3,
   retryDelay: 500,
   // https://github.com/unjs/ofetch#%EF%B8%8F-auto-retry
   retryStatusCodes: [408, 409, 425, 429, 500, 502, 503, 504],
-  debug: false,
 }
 
 export const createFetch = (userOptions: Partial<CreateFetchOptions>): typeof globalThis.fetch => {
@@ -28,7 +28,7 @@ export const createFetch = (userOptions: Partial<CreateFetchOptions>): typeof gl
       options.debug && console.warn('[xsfetch] Failed, retrying... Times left:', retriesLeft)
       await sleep(options.retryDelay)
 
-      return () => xsfetch(retriesLeft - 1, input, init)
+      return async () => xsfetch(retriesLeft - 1, input, init)
     }
     else {
       return res

--- a/packages/xsfetch/src/index.ts
+++ b/packages/xsfetch/src/index.ts
@@ -2,32 +2,33 @@ import { sleep } from '../../utils-stream/src/_sleep'
 
 export interface CreateFetchOptions {
   retry: number
-  /** @internal */
-  retryCount: number
   retryDelay: number
   retryStatusCodes: number[]
+  debug: boolean
+}
+
+export const defaultCreateFetchOptions: CreateFetchOptions = {
+  retry: 3,
+  retryDelay: 500,
+  // https://github.com/unjs/ofetch#%EF%B8%8F-auto-retry
+  retryStatusCodes: [408, 409, 425, 429, 500, 502, 503, 504],
+  debug: false,
 }
 
 export const createFetch = (userOptions: Partial<CreateFetchOptions>): typeof globalThis.fetch => {
-  const options: CreateFetchOptions = {
-    retry: 3,
-    retryCount: 0,
-    retryDelay: 500,
-    // https://github.com/unjs/ofetch#%EF%B8%8F-auto-retry
-    retryStatusCodes: [408, 409, 425, 429, 500, 502, 503, 504],
+  const options: Readonly<CreateFetchOptions> = {
+    ...defaultCreateFetchOptions,
     ...userOptions,
   }
 
-  const xsfetch = async (options: CreateFetchOptions, input: Request | string | URL, init?: RequestInit) => {
+  const xsfetch = async (retriesLeft: number, input: Request | string | URL, init?: RequestInit) => {
     const res = await fetch(input, init)
 
-    if (!res.ok && options.retryStatusCodes.includes(res.status) && options.retry < options.retryCount) {
+    if (!res.ok && retriesLeft > 0 && options.retryStatusCodes.includes(res.status)) {
+      options.debug && console.warn('[xsfetch] Failed, retrying... Times left:', retriesLeft)
       await sleep(options.retryDelay)
 
-      return async () => xsfetch({
-        ...options,
-        retryCount: options.retryCount + 1,
-      }, input, init)
+      return () => xsfetch(retriesLeft - 1, input, init)
     }
     else {
       return res
@@ -35,7 +36,7 @@ export const createFetch = (userOptions: Partial<CreateFetchOptions>): typeof gl
   }
 
   return async (input: Request | string | URL, init?: RequestInit) => {
-    let res = await xsfetch(options, input, init)
+    let res = await xsfetch(options.retry, input, init)
 
     while (typeof res === 'function')
       res = await res()


### PR DESCRIPTION
Hi, I've found an issue in xsfetch that `retry` does not take effect.
Essentially it's `options.retry < options.retryCount` needs to be `options.retry > options.retryCount`.

It can be easily reproduced by the following code (you might add some debug logs in the retry logic to see that it is not executed):

```typescript
import { createFetch } from 'xsfetch';

const fetch = createFetch({
  retry: 3,
  retryDelay: 1000,
  retryStatusCodes: [404],
});

fetch('https://jsonplaceholder.typicode.com/todos/500')
  .then(console.log, console.error);
```

This PR is fixing the issue and also performing a little bit refactoring that eliminates the need for exposing `retryCount` in the fetch options.