### PR TITLE
chore(providers): remove preview suffix from qwq-32b

### DIFF
--- a/packages-ext/providers-cloud/src/providers/deepinfra.ts
+++ b/packages-ext/providers-cloud/src/providers/deepinfra.ts
@@ -22,7 +22,7 @@ export const createDeepInfra = (apiKey: string, baseURL = 'https://api.deepinfra
     | 'Qwen/QVQ-72B-Preview'
     | 'Qwen/Qwen2.5-72B-Instruct'
     | 'Qwen/Qwen2.5-Coder-32B-Instruct'
-    | 'Qwen/QwQ-32B-Preview'
+    | 'Qwen/QwQ-32B'
   >({ apiKey, baseURL }),
   createModelProvider({ apiKey, baseURL }),
   createEmbedProvider<

--- a/packages-ext/providers-cloud/src/providers/fireworks.ts
+++ b/packages-ext/providers-cloud/src/providers/fireworks.ts
@@ -16,7 +16,7 @@ export const createFireworks = (apiKey: string, baseURL = 'https://api.fireworks
     | 'accounts/fireworks/models/phi-3-vision-128k-instruct'
     | 'accounts/fireworks/models/qwen2p5-72b-instruct'
     | 'accounts/fireworks/models/qwen2p5-coder-32b-instruct'
-    | 'accounts/fireworks/models/qwen-qwq-32b-preview'
+    | 'accounts/fireworks/models/qwen-qwq-32b'
   >({ apiKey, baseURL }),
   createEmbedProvider<'nomic-ai/nomic-embed-text-v1.5'>({ apiKey, baseURL }),
   createModelProvider({ apiKey, baseURL }),

--- a/packages-ext/providers-cloud/src/providers/qwen.ts
+++ b/packages-ext/providers-cloud/src/providers/qwen.ts
@@ -19,7 +19,7 @@ export const createQwen = (apiKey: string, baseURL = 'https://dashscope.aliyuncs
     | 'qwen-max'
     | 'qwen-plus'
     | 'qwen-turbo'
-    | 'qwq-32b-preview'
+    | 'qwq-32b'
   >({ apiKey, baseURL }),
   createEmbedProvider<'text-embedding-v3'>({ apiKey, baseURL }),
   createModelProvider({ apiKey, baseURL }),

--- a/packages-ext/providers-cloud/src/providers/silicon-flow.ts
+++ b/packages-ext/providers-cloud/src/providers/silicon-flow.ts
@@ -21,7 +21,7 @@ export const createSiliconFlow = (apiKey: string, baseURL = 'https://api.silicon
     | 'Qwen/Qwen2.5-72B-Instruct'
     | 'Qwen/Qwen2.5-72B-Instruct-128K'
     | 'Qwen/Qwen2.5-Coder-32B-Instruct'
-    | 'Qwen/QwQ-32B-Preview'
+    | 'Qwen/QwQ-32B'
   >({ apiKey, baseURL }),
   createEmbedProvider<
     | 'BAAI/bge-reranker-v2-m3'

--- a/packages-ext/providers-cloud/src/providers/together-ai.ts
+++ b/packages-ext/providers-cloud/src/providers/together-ai.ts
@@ -19,7 +19,7 @@ export const createTogetherAI = (apiKey: string, baseURL = 'https://api.together
     | 'meta-llama/Llama-Vision-Free'
     | 'Qwen/Qwen2.5-72B-Instruct-Turbo'
     | 'Qwen/Qwen2.5-Coder-32B-Instruct'
-    | 'Qwen/QwQ-32B-Preview'
+    | 'Qwen/QwQ-32B'
   >({ apiKey, baseURL }),
   createEmbedProvider<'BAAI/bge-base-en-v1.5' | 'BAAI/bge-large-en-v1.5'>({ apiKey, baseURL }),
   createModelProvider({


### PR DESCRIPTION
This PR removes the "-preview" suffix from all qwq-32b model references across the codebase.

Changes made:
- Removed "-preview" suffix from qwq-32b model references in:
  - deepinfra.ts
  - fireworks.ts
  - qwen.ts
  - silicon-flow.ts
  - together-ai.ts

This reflects the model's transition from preview status to general availability.

Reference qwq-32b news source:
- https://x.com/Alibaba_Qwen/status/1897361654763151544
- https://x.com/FireworksAI_HQ/status/1897712483617718420
- https://cloud.siliconflow.cn/models?mfs=QwQ