### PR TITLE
feat(stream-text): add event handling callbacks for streaming events

### DIFF
--- a/packages/stream-text/src/event.ts
+++ b/packages/stream-text/src/event.ts
@@ -1,0 +1,11 @@
+import type { FinishReason, ToolCall, ToolMessagePart, Usage } from '@xsai/shared-chat'
+
+export type StreamTextEvent =
+  | { error: unknown, type: 'error' }
+  | { error?: unknown, id: string, result?: string | ToolMessagePart[], type: 'tool-call-result' }
+  | { finishReason?: FinishReason, type: 'finish', usage?: Usage }
+  | { reasoning: string, type: 'reasoning' }
+  | { refusal: string, type: 'refusal' }
+  | { text: string, type: 'text-delta' }
+  | { toolCall: ToolCall, type: 'tool-call' }
+  | { toolCall: ToolCall, type: 'tool-call-delta' }

--- a/packages/stream-text/src/index.ts
+++ b/packages/stream-text/src/index.ts
@@ -255,7 +255,9 @@ export const streamText = async (options: StreamTextOptions): Promise<StreamText
         }
 
         if (finish_reason !== undefined) {
-          finishReason = step.finishReason = choiceSnapshot.finishReason = finish_reason
+          finishReason = finish_reason
+          step.finishReason = finish_reason
+          choiceSnapshot.finishReason = finish_reason
 
           if (finish_reason === 'length') {
             throw new XSAIError('length exceeded')

--- a/packages/stream-text/src/index.ts
+++ b/packages/stream-text/src/index.ts
@@ -3,6 +3,8 @@ import type { AssistantMessage, ChatOptions, CompletionToolCall, CompletionToolR
 import { objCamelToSnake, XSAIError } from '@xsai/shared'
 import { chat, determineStepType, executeTool } from '@xsai/shared-chat'
 
+import type { StreamTextEvent } from './event'
+
 import { parseChunk } from './helper'
 
 export interface StreamTextChunkResult {
@@ -37,6 +39,12 @@ export interface StreamTextOptions extends ChatOptions {
    * @param chunk - The current chunk of the stream.
    */
   onChunk?: (chunk: StreamTextChunkResult) => Promise<unknown> | unknown
+
+  /**
+   * Callback function that is called with each event of the stream.
+   * @param event - The current event of the stream.
+   */
+  onEvent?: (event: StreamTextEvent) => Promise<unknown> | unknown
 
   /**
    * Callback function that is called when the stream is finished.
@@ -163,6 +171,8 @@ export const streamText = async (options: StreamTextOptions): Promise<StreamText
     }
     const choiceState: Record<string, StreamTextChoiceState> = {}
     let buffer = ''
+    let finishReason: FinishReason | undefined
+    let usage: undefined | Usage
     let shouldOutputText: boolean = true
 
     const endToolCallByIndex = (state: StreamTextChoiceState, idx: number) => {
@@ -209,10 +219,19 @@ export const streamText = async (options: StreamTextOptions): Promise<StreamText
         stepCtrl.error(reason)
         textCtrl.error(reason)
       },
+      close: () => {
+        options.onEvent?.({
+          finishReason,
+          type: 'finish',
+          usage,
+        })
+      },
       // eslint-disable-next-line sonarjs/cognitive-complexity
       write: async (chunk) => {
         options.onChunk?.(chunk)
         chunkCtrl.enqueue(chunk)
+
+        usage = chunk.usage
 
         const choice = chunk.choices[0]
 
@@ -236,8 +255,7 @@ export const streamText = async (options: StreamTextOptions): Promise<StreamText
         }
 
         if (finish_reason !== undefined) {
-          step.finishReason = finish_reason
-          choiceSnapshot.finishReason = finish_reason
+          finishReason = step.finishReason = choiceSnapshot.finishReason = finish_reason
 
           if (finish_reason === 'length') {
             throw new XSAIError('length exceeded')
@@ -257,15 +275,31 @@ export const streamText = async (options: StreamTextOptions): Promise<StreamText
         if (refusal !== undefined) {
           // eslint-disable-next-line ts/strict-boolean-expressions
           message.refusal = (message.refusal || '') + (refusal || '')
+
+          options.onEvent?.({
+            refusal: message.refusal,
+            type: 'refusal',
+          })
         }
 
         if (content !== undefined) {
           // eslint-disable-next-line ts/strict-boolean-expressions
           message.content = (message.content || '') + (content || '')
           shouldOutputText && textCtrl?.enqueue(content)
+
+          options.onEvent?.({
+            text: content,
+            type: 'text-delta',
+          })
         }
 
-        for (const { function: fn, id, index, type } of tool_calls || []) {
+        for (const tool_call of tool_calls || []) {
+          options.onEvent?.({
+            toolCall: tool_call,
+            type: 'tool-call-delta',
+          })
+
+          const { function: fn, id, index, type } = tool_call
           message.toolCalls ??= {}
 
           const toolCall = message.toolCalls[index] ??= {
@@ -347,6 +381,11 @@ export const streamText = async (options: StreamTextOptions): Promise<StreamText
           return
         }
 
+        options.onEvent?.({
+          toolCall,
+          type: 'tool-call',
+        })
+
         try {
           const { parsedArgs, result, toolName } = await executeTool({
             abortSignal: options.abortSignal,
@@ -368,6 +407,12 @@ export const streamText = async (options: StreamTextOptions): Promise<StreamText
             result,
             toolCallId: toolCall.id,
             toolName,
+          })
+
+          options.onEvent?.({
+            id: toolCall.id,
+            result,
+            type: 'tool-call-result',
           })
         }
         catch (error) {


### PR DESCRIPTION
Add an optional callback function parameter to expose intermediate data during the data processing process, providing it for secondary development