### PR TITLE
refactor(xsschema): bump zod, use `zod/v4` import

### DIFF
--- a/packages-top/xsschema/package.json
+++ b/packages-top/xsschema/package.json
@@ -46,7 +46,7 @@
     "arktype": "catalog:schema",
     "effect": "catalog:schema",
     "sury": "^10.0.0-rc",
-    "zod": "^3.24.3 || ^4.0.0-beta",
+    "zod": "catalog:schema",
     "zod-to-json-schema": "catalog:schema"
   },
   "peerDependenciesMeta": {
@@ -76,13 +76,12 @@
     "@standard-schema/spec": "^1.0.0",
     "@types/json-schema": "^7.0.15",
     "@valibot/to-json-schema": "catalog:schema",
-    "@zod/mini": "^4.0.0-beta.20250420T053007",
+    "@zod/mini": "^4.0.0-beta",
     "arktype": "catalog:schema",
     "effect": "catalog:schema",
     "sury": "catalog:schema",
     "valibot": "catalog:schema",
     "zod": "catalog:schema",
-    "zod-to-json-schema": "catalog:schema",
-    "zod4": "npm:zod@^4.0.0-beta.20250420T053007"
+    "zod-to-json-schema": "catalog:schema"
   }
 }

--- a/packages-top/xsschema/src/to-json-schema/vendors/zod.ts
+++ b/packages-top/xsschema/src/to-json-schema/vendors/zod.ts
@@ -1,26 +1,26 @@
 import type { ZodSchema } from 'zod'
-import type { ZodType } from 'zod4'
+import type { ZodType } from 'zod/v4'
 
 import type { ToJsonSchemaFn } from '.'
 
 export const getToJsonSchemaFn = async (): Promise<ToJsonSchemaFn> => {
-  let toJSONSchema: ToJsonSchemaFn = (_schema: unknown) => {
-    throw new Error('xsschema: Missing dependencies "zod" or "@zod/mini".')
+  let zodV4toJSONSchema: ToJsonSchemaFn = (_schema: unknown) => {
+    throw new Error('xsschema: Missing zod v4 dependencies "zod" or "@zod/mini".')
   }
   let zodToJSONSchema: ToJsonSchemaFn = (_schema: unknown) => {
-    throw new Error('xsschema: Missing dependencies "zod-to-json-schema".')
+    throw new Error('xsschema: Missing zod v3 dependencies "zod-to-json-schema".')
   }
 
   try {
     const { z } = await import('@zod/mini')
-    toJSONSchema = z.toJSONSchema as ToJsonSchemaFn
+    zodV4toJSONSchema = z.toJSONSchema as ToJsonSchemaFn
   }
   catch {}
 
   try {
     const { z } = await import('zod')
     if ('toJSONSchema' in z)
-      toJSONSchema = z.toJSONSchema as ToJsonSchemaFn
+      zodToJSONSchema = z.toJSONSchema as ToJsonSchemaFn
   }
   catch (err) {
     if (err instanceof Error)
@@ -36,9 +36,18 @@ export const getToJsonSchemaFn = async (): Promise<ToJsonSchemaFn> => {
       console.error(err.message)
   }
 
+  try {
+    const { z } = await import('zod/v4')
+    zodV4toJSONSchema = z.toJSONSchema as ToJsonSchemaFn
+  }
+  catch (err) {
+    if (err instanceof Error)
+      console.error(err.message)
+  }
+
   return async (schema: unknown) => {
     if ('_zod' in (schema as ZodSchema | ZodType))
-      return toJSONSchema(schema)
+      return zodV4toJSONSchema(schema)
     else
       return zodToJSONSchema(schema)
   }

--- a/packages-top/xsschema/src/to-json-schema/vendors/zod.ts
+++ b/packages-top/xsschema/src/to-json-schema/vendors/zod.ts
@@ -18,9 +18,9 @@ export const getToJsonSchemaFn = async (): Promise<ToJsonSchemaFn> => {
   catch {}
 
   try {
-    const { z } = await import('zod')
+    const { z } = await import('zod/v4')
     if ('toJSONSchema' in z)
-      zodToJSONSchema = z.toJSONSchema as ToJsonSchemaFn
+      zodV4toJSONSchema = z.toJSONSchema as ToJsonSchemaFn
   }
   catch (err) {
     if (err instanceof Error)
@@ -30,15 +30,6 @@ export const getToJsonSchemaFn = async (): Promise<ToJsonSchemaFn> => {
   try {
     const { zodToJsonSchema } = await import('zod-to-json-schema')
     zodToJSONSchema = zodToJsonSchema as ToJsonSchemaFn
-  }
-  catch (err) {
-    if (err instanceof Error)
-      console.error(err.message)
-  }
-
-  try {
-    const { z } = await import('zod/v4')
-    zodV4toJSONSchema = z.toJSONSchema as ToJsonSchemaFn
   }
   catch (err) {
     if (err instanceof Error)

--- a/packages-top/xsschema/test/__snapshots__/to-json-schema.test.ts.snap
+++ b/packages-top/xsschema/test/__snapshots__/to-json-schema.test.ts.snap
@@ -218,6 +218,7 @@ exports[`toJsonSchema > valibot sync 1`] = `
 
 exports[`toJsonSchema > zod 1`] = `
 {
+  "$schema": "https://json-schema.org/draft-2020-12/schema",
   "description": "My neat object schema",
   "properties": {
     "myString": {
@@ -268,6 +269,7 @@ exports[`toJsonSchema > zod 2`] = `
 
 exports[`toJsonSchema > zod 3`] = `
 {
+  "$schema": "https://json-schema.org/draft-2020-12/schema",
   "properties": {
     "myString": {
       "type": "string",
@@ -293,6 +295,7 @@ exports[`toJsonSchema > zod 3`] = `
 
 exports[`toJsonSchema > zod sync 1`] = `
 {
+  "$schema": "https://json-schema.org/draft-2020-12/schema",
   "description": "My neat object schema",
   "properties": {
     "myString": {
@@ -343,6 +346,7 @@ exports[`toJsonSchema > zod sync 2`] = `
 
 exports[`toJsonSchema > zod sync 3`] = `
 {
+  "$schema": "https://json-schema.org/draft-2020-12/schema",
   "properties": {
     "myString": {
       "type": "string",

--- a/packages-top/xsschema/test/to-json-schema.test.ts
+++ b/packages-top/xsschema/test/to-json-schema.test.ts
@@ -1,11 +1,11 @@
-import { z as zm } from '@zod/mini'
 import { type } from 'arktype'
 import { Schema } from 'effect'
 import * as S from 'sury'
 import * as v from 'valibot'
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { z as z4 } from 'zod4'
+import { z as z4 } from 'zod/v4'
+import { z as zm } from 'zod/v4-mini'
 
 import { initToJsonSchemaSyncVendor, toJsonSchema, toJsonSchemaSync } from '../src'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ catalogs:
       specifier: ^1.0.0
       version: 1.0.0
     zod:
-      specifier: ^3.24.3
-      version: 3.24.3
+      specifier: ^3.25.0
+      version: 3.25.20
     zod-to-json-schema:
       specifier: ^3.24.5
       version: 3.24.5
@@ -228,7 +228,7 @@ importers:
         version: link:../packages-top/xsschema
       zod:
         specifier: catalog:schema
-        version: 3.24.3
+        version: 3.25.20
 
   packages-ext/compat:
     dependencies:
@@ -333,8 +333,8 @@ importers:
         specifier: catalog:schema
         version: 1.0.0(valibot@1.0.0(typescript@5.6.3))
       '@zod/mini':
-        specifier: ^4.0.0-beta.20250420T053007
-        version: 4.0.0-beta.20250420T053007
+        specifier: ^4.0.0-beta
+        version: 4.0.0-beta.0
       arktype:
         specifier: catalog:schema
         version: 2.1.16
@@ -349,13 +349,10 @@ importers:
         version: 1.0.0(typescript@5.6.3)
       zod:
         specifier: catalog:schema
-        version: 3.24.3
+        version: 3.25.20
       zod-to-json-schema:
         specifier: catalog:schema
-        version: 3.24.5(zod@3.24.3)
-      zod4:
-        specifier: npm:zod@^4.0.0-beta.20250420T053007
-        version: zod@4.0.0-beta.20250420T053007
+        version: 3.24.5(zod@3.25.20)
 
   packages/embed:
     dependencies:
@@ -2457,11 +2454,11 @@ packages:
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
 
-  '@zod/core@0.8.1':
-    resolution: {integrity: sha512-djj8hPhxIHcG8ptxITaw/Bout5HJZ9NyRbKr95Eilqwt9R0kvITwUQGDU+n+MVdsBIka5KwztmZSLti22F+P0A==}
+  '@zod/core@0.1.0':
+    resolution: {integrity: sha512-hSXsufqjH7u8DiJPT0KY1rFWIhjkdXGM8MhMLwzaeOMhxMA4bzjWLQwSoAToJunUTVrpmfdo4dUFzNaU219+VQ==}
 
-  '@zod/mini@4.0.0-beta.20250420T053007':
-    resolution: {integrity: sha512-PnQwkzlUbUj6A2GKbqhskH/v58m2WfmP+dbXevzzMdvVA7H/KNao37YWhHOTjBzf+xykCXNoLwfwnPMIsU0hOA==}
+  '@zod/mini@4.0.0-beta.0':
+    resolution: {integrity: sha512-ux1pJYQJO0S/uAldc0KGKiBFvqPpQqfC8vXbBJ3tDrcWCCa6/QBQPexZFn/cHscTxA/SnEJEAxa7qGTwPQC5Tg==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -5653,8 +5650,8 @@ packages:
   zod@3.24.3:
     resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
 
-  zod@4.0.0-beta.20250420T053007:
-    resolution: {integrity: sha512-5pp8Q0PNDaNcUptGiBE9akyioJh3RJpagIxrLtAVMR9IxwcSZiOsJD/1/98CyhItdTlI2H91MfhhLzRlU+fifA==}
+  zod@3.25.20:
+    resolution: {integrity: sha512-z03fqpTMDF1G02VLKUMt6vyACE7rNWkh3gpXVHgPTw28NPtDFRGvcpTtPwn2kMKtQ0idtYJUTxchytmnqYswcw==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -7498,11 +7495,11 @@ snapshots:
 
   '@vue/shared@3.5.13': {}
 
-  '@zod/core@0.8.1': {}
+  '@zod/core@0.1.0': {}
 
-  '@zod/mini@4.0.0-beta.20250420T053007':
+  '@zod/mini@4.0.0-beta.0':
     dependencies:
-      '@zod/core': 0.8.1
+      '@zod/core': 0.1.0
 
   accepts@2.0.0:
     dependencies:
@@ -8889,7 +8886,7 @@ snapshots:
       npm-to-yarn: 3.0.1
       oxc-transform: 0.53.0
       unist-util-visit: 5.0.0
-      zod: 3.24.3
+      zod: 3.25.20
 
   fumadocs-mdx@11.5.7(acorn@8.14.0)(fumadocs-core@15.1.3(@types/react@19.1.0)(next@15.2.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@15.2.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
     dependencies:
@@ -8904,7 +8901,7 @@ snapshots:
       gray-matter: 4.0.3
       next: 15.2.4(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       unist-util-visit: 5.0.0
-      zod: 3.24.3
+      zod: 3.25.20
     transitivePeerDependencies:
       - acorn
       - supports-color
@@ -11515,10 +11512,12 @@ snapshots:
     dependencies:
       zod: 3.24.3
 
+  zod-to-json-schema@3.24.5(zod@3.25.20):
+    dependencies:
+      zod: 3.25.20
+
   zod@3.24.3: {}
 
-  zod@4.0.0-beta.20250420T053007:
-    dependencies:
-      '@zod/core': 0.8.1
+  zod@3.25.20: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,5 +17,5 @@ catalogs:
     effect: ^3.14.5
     sury: ^10.0.0-rc.4
     valibot: *valibot
-    zod: ^3.24.3
+    zod: ^3.25.0
     zod-to-json-schema: ^3.24.5


### PR DESCRIPTION
Zod v4 was just released to stable; the new APIs will no longer be accessible via a new v4 version, rather via a `zod/v4` import.

Changes made:
- updated workspace dependencies to use zod ^v3.25.0
- updated test snapshots to include now-generated `$schema` values
- updated vendor toJSONSchema logic to include `zod/v4` lookup
