### PR TITLE
Add player 2 as a local provider

### DIFF
--- a/packages-ext/providers-cloud/src/providers/player2.ts
+++ b/packages-ext/providers-cloud/src/providers/player2.ts
@@ -1,0 +1,9 @@
+import {
+  createChatProvider,
+  createMetadataProvider,
+  createSpeechProvider,
+  createTranscriptionProvider,
+  merge,
+} from '@xsai-ext/shared-providers'
+
+export const createPlayer2 = (baseURL = 'http://localhost:4315/v1/') => merge(createMetadataProvider('player2-api'), createChatProvider({ baseURL }), createSpeechProvider({ baseURL }), createTranscriptionProvider({ baseURL }))

--- a/packages-ext/providers-cloud/src/providers/player2.ts
+++ b/packages-ext/providers-cloud/src/providers/player2.ts
@@ -1,9 +1,0 @@
-import {
-  createChatProvider,
-  createMetadataProvider,
-  createSpeechProvider,
-  createTranscriptionProvider,
-  merge,
-} from '@xsai-ext/shared-providers'
-
-export const createPlayer2 = (baseURL = 'http://localhost:4315/v1/') => merge(createMetadataProvider('player2-api'), createChatProvider({ baseURL }), createSpeechProvider({ baseURL }), createTranscriptionProvider({ baseURL }))

--- a/packages-ext/providers-local/src/providers/index.ts
+++ b/packages-ext/providers-local/src/providers/index.ts
@@ -1,4 +1,5 @@
 export { createLiteLLM } from './litellm'
 export { createLMStudio } from './lmstudio'
 export { createOllama } from './ollama'
+export { createPlayer2 } from './player2'
 export { createSpeaches } from './speaches'

--- a/packages-ext/providers-local/src/providers/player2.ts
+++ b/packages-ext/providers-local/src/providers/player2.ts
@@ -4,4 +4,4 @@ import {
   merge,
 } from '@xsai-ext/shared-providers'
 
-export const createPlayer2 = (baseURL = 'http://localhost:4315/v1/') => merge(createMetadataProvider('player2-api'), createChatProvider({ baseURL }))
+export const createPlayer2 = (baseURL = 'http://localhost:4315/v1/') => merge(createMetadataProvider('player2'), createChatProvider({ baseURL }))

--- a/packages-ext/providers-local/src/providers/player2.ts
+++ b/packages-ext/providers-local/src/providers/player2.ts
@@ -1,0 +1,7 @@
+import {
+  createChatProvider,
+  createMetadataProvider,
+  merge,
+} from '@xsai-ext/shared-providers'
+
+export const createPlayer2 = (baseURL = 'http://localhost:4315/v1/') => merge(createMetadataProvider('player2-api'), createChatProvider({ baseURL }))


### PR DESCRIPTION
This PR adds player2 as a local provider, we fixed our API so that it would be compatible (the new version of our app should be available soon, meaning just a few days). I have tested both generateText and streamText, both appear to work.