### PR TITLE
fix(stream-text): return streams without blocking

### DIFF
--- a/packages/stream-text/test/__snapshots__/index.test.ts.snap
+++ b/packages/stream-text/test/__snapshots__/index.test.ts.snap
@@ -1,8 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`@xsai/stream-text basic > basic 1`] = `Promise {}`;
-
-exports[`@xsai/stream-text basic > basic 2`] = `
+exports[`@xsai/stream-text basic > basic 1`] = `
 [
   {
     "text": "YES",
@@ -20,9 +18,9 @@ exports[`@xsai/stream-text basic > basic 2`] = `
 ]
 `;
 
-exports[`@xsai/stream-text basic > stream 1`] = `Promise {}`;
+exports[`@xsai/stream-text basic > basic 2`] = `Promise {}`;
 
-exports[`@xsai/stream-text basic > stream 2`] = `
+exports[`@xsai/stream-text basic > stream 1`] = `
 [
   {
     "text": "Why",
@@ -95,3 +93,5 @@ exports[`@xsai/stream-text basic > stream 2`] = `
   },
 ]
 `;
+
+exports[`@xsai/stream-text basic > stream 2`] = `Promise {}`;

--- a/packages/stream-text/test/index.test.ts
+++ b/packages/stream-text/test/index.test.ts
@@ -22,8 +22,6 @@ describe('@xsai/stream-text basic', async () => {
       seed: 114514,
     })
 
-    expect(steps).toMatchSnapshot()
-
     let text = ''
     for await (const t of textStream) {
       text += t
@@ -42,6 +40,8 @@ describe('@xsai/stream-text basic', async () => {
       )
     }
     expect(events).toMatchSnapshot()
+
+    expect(steps).toMatchSnapshot()
   })
 
   it('stream', async () => {
@@ -61,8 +61,6 @@ describe('@xsai/stream-text basic', async () => {
       seed: 114514,
     })
 
-    expect(steps).toMatchSnapshot()
-
     const text = []
     for await (const t of textStream) {
       text.push(t)
@@ -74,5 +72,7 @@ describe('@xsai/stream-text basic', async () => {
       events.push(event)
     }
     expect(events).toMatchSnapshot()
+
+    expect(steps).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
Make `streamText` return streams to allow consuming the streams as early as possible.