### PR TITLE
feat(stream-text): support total usage

### DIFF
--- a/packages/stream-text/test/__snapshots__/index.test.ts.snap
+++ b/packages/stream-text/test/__snapshots__/index.test.ts.snap
@@ -18,7 +18,113 @@ exports[`@xsai/stream-text basic > basic 1`] = `
 ]
 `;
 
-exports[`@xsai/stream-text basic > basic 2`] = `Promise {}`;
+exports[`@xsai/stream-text basic > basic 2`] = `
+[
+  {
+    "finishReason": "stop",
+    "stepType": "initial",
+    "text": "YES",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": undefined,
+  },
+]
+`;
+
+exports[`@xsai/stream-text basic > includes usage 1`] = `
+[
+  {
+    "text": "Why",
+    "type": "text-delta",
+  },
+  {
+    "text": " don",
+    "type": "text-delta",
+  },
+  {
+    "text": "'t",
+    "type": "text-delta",
+  },
+  {
+    "text": " sc",
+    "type": "text-delta",
+  },
+  {
+    "text": "ient",
+    "type": "text-delta",
+  },
+  {
+    "text": "ists",
+    "type": "text-delta",
+  },
+  {
+    "text": " trust",
+    "type": "text-delta",
+  },
+  {
+    "text": " atoms",
+    "type": "text-delta",
+  },
+  {
+    "text": "?",
+    "type": "text-delta",
+  },
+  {
+    "text": " Because",
+    "type": "text-delta",
+  },
+  {
+    "text": " they",
+    "type": "text-delta",
+  },
+  {
+    "text": " make",
+    "type": "text-delta",
+  },
+  {
+    "text": " up",
+    "type": "text-delta",
+  },
+  {
+    "text": " everything",
+    "type": "text-delta",
+  },
+  {
+    "text": "!",
+    "type": "text-delta",
+  },
+  {
+    "text": "",
+    "type": "text-delta",
+  },
+  {
+    "finishReason": "stop",
+    "type": "finish",
+    "usage": {
+      "completion_tokens": 16,
+      "prompt_tokens": 25,
+      "total_tokens": 41,
+    },
+  },
+]
+`;
+
+exports[`@xsai/stream-text basic > includes usage 2`] = `
+[
+  {
+    "finishReason": "stop",
+    "stepType": "initial",
+    "text": "Why don't scientists trust atoms? Because they make up everything!",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": {
+      "completion_tokens": 16,
+      "prompt_tokens": 25,
+      "total_tokens": 41,
+    },
+  },
+]
+`;
 
 exports[`@xsai/stream-text basic > stream 1`] = `
 [
@@ -94,4 +200,15 @@ exports[`@xsai/stream-text basic > stream 1`] = `
 ]
 `;
 
-exports[`@xsai/stream-text basic > stream 2`] = `Promise {}`;
+exports[`@xsai/stream-text basic > stream 2`] = `
+[
+  {
+    "finishReason": "stop",
+    "stepType": "initial",
+    "text": "Why don't scientists trust atoms? Because they make up everything!",
+    "toolCalls": [],
+    "toolResults": [],
+    "usage": undefined,
+  },
+]
+`;

--- a/packages/stream-text/test/index.test.ts
+++ b/packages/stream-text/test/index.test.ts
@@ -41,7 +41,7 @@ describe('@xsai/stream-text basic', async () => {
     }
     expect(events).toMatchSnapshot()
 
-    expect(steps).toMatchSnapshot()
+    await expect(steps).resolves.toMatchSnapshot()
   })
 
   it('stream', async () => {
@@ -73,6 +73,41 @@ describe('@xsai/stream-text basic', async () => {
     }
     expect(events).toMatchSnapshot()
 
-    expect(steps).toMatchSnapshot()
+    await expect(steps).resolves.toMatchSnapshot()
+  })
+
+  it('includes usage', async () => {
+    const { fullStream, steps, textStream } = streamText({
+      baseURL: 'http://localhost:11434/v1/',
+      messages: [
+        {
+          content: 'You are a helpful assistant.',
+          role: 'system',
+        },
+        {
+          content: 'Please tell a short joke',
+          role: 'user',
+        },
+      ],
+      model: 'granite3.3:2b',
+      seed: 114514,
+      streamOptions: {
+        includeUsage: true,
+      },
+    })
+
+    const text = []
+    for await (const t of textStream) {
+      text.push(t)
+    }
+    expect(text.length).toBeGreaterThan(1)
+
+    const events: StreamTextEvent[] = []
+    for await (const event of fullStream) {
+      events.push(event)
+    }
+    expect(events).toMatchSnapshot()
+
+    await expect(steps).resolves.toMatchSnapshot()
   })
 })


### PR DESCRIPTION
Includes `totalUsage` in the return value from `streamText`.