### PR TITLE
fix(stream-text): accessing a null index during tool call

### DIFF
--- a/packages-ext/telemetry/src/utils/stream-text.ts
+++ b/packages-ext/telemetry/src/utils/stream-text.ts
@@ -182,7 +182,7 @@ export const streamText = (options: WithTelemetry<StreamTextOptions>) => {
 
     if (tool_calls.length !== 0) {
       for (const toolCall of tool_calls) {
-        if (!toolCall)
+        if (toolCall == null)
           continue
         const { completionToolCall, completionToolResult, message } = await executeTool({
           abortSignal: options.abortSignal,

--- a/packages-ext/telemetry/src/utils/stream-text.ts
+++ b/packages-ext/telemetry/src/utils/stream-text.ts
@@ -182,7 +182,8 @@ export const streamText = (options: WithTelemetry<StreamTextOptions>) => {
 
     if (tool_calls.length !== 0) {
       for (const toolCall of tool_calls) {
-        if (!toolCall) continue
+        if (!toolCall)
+          continue
         const { completionToolCall, completionToolResult, message } = await executeTool({
           abortSignal: options.abortSignal,
           messages,

--- a/packages-ext/telemetry/src/utils/stream-text.ts
+++ b/packages-ext/telemetry/src/utils/stream-text.ts
@@ -182,6 +182,7 @@ export const streamText = (options: WithTelemetry<StreamTextOptions>) => {
 
     if (tool_calls.length !== 0) {
       for (const toolCall of tool_calls) {
+        if (!toolCall) continue
         const { completionToolCall, completionToolResult, message } = await executeTool({
           abortSignal: options.abortSignal,
           messages,

--- a/packages/stream-text/src/index.ts
+++ b/packages/stream-text/src/index.ts
@@ -164,7 +164,8 @@ export const streamText = (options: StreamTextOptions): StreamTextResult => {
 
     if (tool_calls.length !== 0) {
       for (const toolCall of tool_calls) {
-        if (!toolCall) continue
+        if (!toolCall)
+          continue
         const { completionToolCall, completionToolResult, message } = await executeTool({
           abortSignal: options.abortSignal,
           messages,

--- a/packages/stream-text/src/index.ts
+++ b/packages/stream-text/src/index.ts
@@ -164,6 +164,7 @@ export const streamText = (options: StreamTextOptions): StreamTextResult => {
 
     if (tool_calls.length !== 0) {
       for (const toolCall of tool_calls) {
+        if (!toolCall) continue
         const { completionToolCall, completionToolResult, message } = await executeTool({
           abortSignal: options.abortSignal,
           messages,

--- a/packages/stream-text/src/index.ts
+++ b/packages/stream-text/src/index.ts
@@ -164,7 +164,7 @@ export const streamText = (options: StreamTextOptions): StreamTextResult => {
 
     if (tool_calls.length !== 0) {
       for (const toolCall of tool_calls) {
-        if (!toolCall)
+        if (toolCall == null)
           continue
         const { completionToolCall, completionToolResult, message } = await executeTool({
           abortSignal: options.abortSignal,


### PR DESCRIPTION
When I used GPT-5, an error occurred ⬇️

```bash
TypeError: undefined is not an object (evaluating 'toolCall.function')
      at <anonymous> (.../node_modules/@xsai/shared-chat/dist/index.js:47:63)
      at find (1:11)
      at <anonymous> (.../node_modules/@xsai/shared-chat/dist/index.js:47:23)
      at executeTool (.../node_modules/@xsai/shared-chat/dist/index.js:45:21)
      at <anonymous> (.../node_modules/@xsai/stream-text/dist/index.js:176:77)
```

I added a log `console.log('choice.delta.tool_calls:', choice.delta.tool_calls)` to test ⬇️

```bash
choice.delta.tool_calls: [
  {
    id: "call_ZkZ7QQcJrrOiDbWLu88Z6ny5",
    index: 1,
    type: "function",
    function: {
      name: "weather",
      arguments: "",
    },
  }
]
choice.delta.tool_calls: [
  {
    index: 1,
...
  }
]
choice.delta.tool_calls: [
  {
    index: 1,
...
  }
]
choice.delta.tool_calls: [
  {
    index: 1,
...
  }
]
```

You can see it. the GPT-5’s first index is 1. Haha, it's very unique.

----

So, I added a simple logic to skip null in the array. This should work for most cases.
