### PR TITLE
refactor(utils-stream)!: remove to async iterator

### DIFF
--- a/docs/content/docs/packages/utils/stream.mdx
+++ b/docs/content/docs/packages/utils/stream.mdx
@@ -55,19 +55,3 @@ const smoothTextStream = textStream.pipeThrough(smoothStream({
   chunking: 'line',
 }))
 ```
-
-### toAsyncIterator
-
-Simple polyfill for Safari. (see https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream#browser_compatibility)
-
-```ts twoslash
-import { simulateReadableStream, toAsyncIterator } from '@xsai/utils-stream'
-
-const stream = simulateReadableStream<number>({
-  chunks: [1, 2, 3],
-  chunkDelay: 100,
-  initialDelay: 0,
-})
-
-const iterableStream = toAsyncIterator(stream)
-```

--- a/packages/utils-stream/src/index.ts
+++ b/packages/utils-stream/src/index.ts
@@ -1,3 +1,2 @@
 export { simulateReadableStream, type SimulateReadableStreamOptions } from './simulate-readable-stream'
 export { smoothStream, type SmoothStreamOptions } from './smooth-stream'
-export { toAsyncIterator } from './to-async-iterator'

--- a/packages/utils-stream/src/to-async-iterator.ts
+++ b/packages/utils-stream/src/to-async-iterator.ts
@@ -1,2 +1,0 @@
-// TODO: deprecate this
-export { readableStreamToAsyncIterator as toAsyncIterator } from '@moeru/std/async-iterator'


### PR DESCRIPTION
Since it appears that no one is using it, I believe it is reasonable to remove it.
If it is still needed, please use https://github.com/moeru-ai/std/blob/main/packages/std/src/async-iterator/index.ts