### PR TITLE
feat(providers): add Baidu Qianfan provider

### DIFF
--- a/packages-ext/providers/scripts/utils/extra.ts
+++ b/packages-ext/providers/scripts/utils/extra.ts
@@ -2,6 +2,15 @@ import type { CodeGenProvider } from './types'
 
 export const extraProviders: CodeGenProvider[] = [
   {
+    apiKey: ['QIANFAN_API_KEY'],
+    baseURL: 'https://qianfan.baidubce.com/v2',
+    capabilities: {},
+    doc: 'https://cloud.baidu.com/doc/qianfan/s/Hmh4suq26',
+    id: 'qianfan',
+    models: [],
+    name: 'Baidu Qianfan',
+  },
+  {
     apiKey: ['TENCENT_HUNYUAN_API_KEY'],
     baseURL: 'https://api.hunyuan.cloud.tencent.com/v1/',
     capabilities: {

--- a/packages-ext/providers/src/generated/create.ts
+++ b/packages-ext/providers/src/generated/create.ts
@@ -813,6 +813,15 @@ export const createZhipuaiCodingPlan = (apiKey: string, baseURL = 'https://open.
 )
 
 /**
+ * Create a Baidu Qianfan Provider
+ * @see {@link https://cloud.baidu.com/doc/qianfan/s/Hmh4suq26}
+ */
+export const createQianfan = (apiKey: string, baseURL = 'https://qianfan.baidubce.com/v2') => merge(
+  createChatProvider({ apiKey, baseURL }),
+  createModelProvider({ apiKey, baseURL }),
+)
+
+/**
  * Create a Tencent Hunyuan Provider
  * @see {@link https://cloud.tencent.com/document/product/1729}
  */

--- a/packages-ext/providers/src/generated/index.ts
+++ b/packages-ext/providers/src/generated/index.ts
@@ -91,6 +91,7 @@ import {
   createZenmux,
   createZhipuai,
   createZhipuaiCodingPlan,
+  createQianfan,
   createTencentHunyuan,
   createOllama,
   createLitellm,
@@ -887,6 +888,15 @@ export const zhipuai = createZhipuai(process.env.ZHIPU_API_KEY ?? '')
  * - apiKey - `ZHIPU_API_KEY`
  */
 export const zhipuaiCodingPlan = createZhipuaiCodingPlan(process.env.ZHIPU_API_KEY ?? '')
+
+/**
+ * Baidu Qianfan Provider
+ * @see {@link https://cloud.baidu.com/doc/qianfan/s/Hmh4suq26}
+ * @remarks
+ * - baseURL - `https://qianfan.baidubce.com/v2`
+ * - apiKey - `QIANFAN_API_KEY`
+ */
+export const qianfan = createQianfan(process.env.QIANFAN_API_KEY ?? '')
 
 /**
  * Tencent Hunyuan Provider

--- a/packages-ext/providers/test/index.test.ts
+++ b/packages-ext/providers/test/index.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { nvidia, qianfan } from '../src'
-import { createQianfan } from '../src/create'
+import { nvidia } from '../src'
 
 describe('@xsai-ext/providers', () => {
   it('nvidia', () => {
@@ -11,27 +10,5 @@ describe('@xsai-ext/providers', () => {
     expect(result.apiKey).toBe('')
     expect(result.baseURL).toBe('https://integrate.api.nvidia.com/v1')
     expect(result.model).toBe(model)
-  })
-
-  it('qianfan', () => {
-    const model = 'ernie-4.0-turbo-8k'
-    const result = qianfan.chat(model)
-
-    expect(result.apiKey).toBe('')
-    expect(result.baseURL).toBe('https://qianfan.baidubce.com/v2')
-    expect(result.model).toBe(model)
-    expect(qianfan.model()).toEqual({
-      apiKey: '',
-      baseURL: 'https://qianfan.baidubce.com/v2',
-    })
-  })
-
-  it('createQianfan accepts a custom baseURL', () => {
-    const provider = createQianfan('test-api-key', 'https://example.com/v2')
-    const result = provider.chat('ernie-3.5-8k')
-
-    expect(result.apiKey).toBe('test-api-key')
-    expect(result.baseURL).toBe('https://example.com/v2')
-    expect(result.model).toBe('ernie-3.5-8k')
   })
 })

--- a/packages-ext/providers/test/index.test.ts
+++ b/packages-ext/providers/test/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { nvidia } from '../src'
+import { createQianfan } from '../src/create'
+import { nvidia, qianfan } from '../src'
 
 describe('@xsai-ext/providers', () => {
   it('nvidia', () => {
@@ -10,5 +11,27 @@ describe('@xsai-ext/providers', () => {
     expect(result.apiKey).toBe('')
     expect(result.baseURL).toBe('https://integrate.api.nvidia.com/v1')
     expect(result.model).toBe(model)
+  })
+
+  it('qianfan', () => {
+    const model = 'ernie-4.0-turbo-8k'
+    const result = qianfan.chat(model)
+
+    expect(result.apiKey).toBe('')
+    expect(result.baseURL).toBe('https://qianfan.baidubce.com/v2')
+    expect(result.model).toBe(model)
+    expect(qianfan.model()).toEqual({
+      apiKey: '',
+      baseURL: 'https://qianfan.baidubce.com/v2',
+    })
+  })
+
+  it('createQianfan accepts a custom baseURL', () => {
+    const provider = createQianfan('test-api-key', 'https://example.com/v2')
+    const result = provider.chat('ernie-3.5-8k')
+
+    expect(result.apiKey).toBe('test-api-key')
+    expect(result.baseURL).toBe('https://example.com/v2')
+    expect(result.model).toBe('ernie-3.5-8k')
   })
 })

--- a/packages-ext/providers/test/index.test.ts
+++ b/packages-ext/providers/test/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { createQianfan } from '../src/create'
 import { nvidia, qianfan } from '../src'
+import { createQianfan } from '../src/create'
 
 describe('@xsai-ext/providers', () => {
   it('nvidia', () => {


### PR DESCRIPTION
## Description

- Add Baidu Qianfan as an OpenAI-compatible provider in `@xsai-ext/providers`.
- Export `createQianfan` and the predefined `qianfan` provider with the default endpoint `https://qianfan.baidubce.com/v2`.
- Add provider tests for default chat config, model config, and custom `baseURL`.

## Linked Issues

None.

## Additional Context

Baidu Qianfan documents OpenAI SDK-compatible usage with `api_key`, `base_url`, and `model` parameters:
https://cloud.baidu.com/doc/qianfan/s/Hmh4suq26

Verified locally:

- `pnpm -F @xsai-ext/providers test`
- `pnpm -F @xsai-ext/providers build`

Manual smoke test with a private Qianfan API key:

- `createQianfan().model()` works with `listModels`
- `createQianfan().chat("ernie-4.0-turbo-8k")` works with `generateText`
- Streaming chat works with `streamText`